### PR TITLE
fix(ui): improve face selection dropdown styling and text visibility in dark theme

### DIFF
--- a/app/src/main/java/com/pv/androidfacefusion/TargetFaceMappingAdapter.java
+++ b/app/src/main/java/com/pv/androidfacefusion/TargetFaceMappingAdapter.java
@@ -111,10 +111,10 @@ public class TargetFaceMappingAdapter extends RecyclerView.Adapter<TargetFaceMap
 
         ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<>(
             context,
-            android.R.layout.simple_spinner_item,
+            R.layout.spinner_selected_item,
             options
         );
-        spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerAdapter.setDropDownViewResource(R.layout.spinner_dropdown_item);
         holder.spinner.setAdapter(spinnerAdapter);
 
         // Pre-select if previously selected

--- a/app/src/main/res/drawable/bg_spinner.xml
+++ b/app/src/main/res/drawable/bg_spinner.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
+    <item>
+        <layer-list>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="?attr/colorSurfaceVariant" />
+                    <stroke
+                        android:width="1dp"
+                        android:color="?attr/colorOutlineVariant" />
+                    <corners android:radius="8dp" />
+                </shape>
+            </item>
+            <item
+                android:width="20dp"
+                android:height="20dp"
+                android:gravity="end|center_vertical"
+                android:end="8dp"
+                android:drawable="@drawable/ic_arrow_drop_down" />
+        </layer-list>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/bg_spinner_popup.xml
+++ b/app/src/main/res/drawable/bg_spinner_popup.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceVariant" />
+    <stroke
+        android:width="1dp"
+        android:color="?attr/colorOutlineVariant" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_arrow_drop_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_drop_down.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnSurfaceVariant"
+        android:pathData="M7,10l5,5 5,-5z" />
+</vector>

--- a/app/src/main/res/layout/item_target_face_mapping.xml
+++ b/app/src/main/res/layout/item_target_face_mapping.xml
@@ -53,7 +53,7 @@
 
         <Spinner
             android:id="@+id/savedFaceSpinner"
-            android:layout_width="170dp"
+            android:layout_width="145dp"
             android:layout_height="48dp"
             android:spinnerMode="dropdown"
             android:background="@drawable/bg_spinner"

--- a/app/src/main/res/layout/item_target_face_mapping.xml
+++ b/app/src/main/res/layout/item_target_face_mapping.xml
@@ -53,10 +53,11 @@
 
         <Spinner
             android:id="@+id/savedFaceSpinner"
-            android:layout_width="160dp"
+            android:layout_width="170dp"
             android:layout_height="48dp"
             android:spinnerMode="dropdown"
-            android:background="@android:drawable/btn_dropdown" />
+            android:background="@drawable/bg_spinner"
+            android:popupBackground="@drawable/bg_spinner_popup" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/spinner_dropdown_item.xml
+++ b/app/src/main/res/layout/spinner_dropdown_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:singleLine="true"
+    android:ellipsize="end"
+    android:textSize="15sp"
+    android:textColor="?attr/colorOnSurface"
+    android:paddingStart="14dp"
+    android:paddingEnd="14dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    android:gravity="center_vertical"
+    android:background="?android:attr/selectableItemBackground" />

--- a/app/src/main/res/layout/spinner_selected_item.xml
+++ b/app/src/main/res/layout/spinner_selected_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:singleLine="true"
+    android:ellipsize="end"
+    android:textSize="15sp"
+    android:textStyle="bold"
+    android:textColor="?attr/colorOnSurface"
+    android:paddingStart="12dp"
+    android:paddingEnd="30dp"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp"
+    android:gravity="center_vertical" />

--- a/app/src/main/res/layout/spinner_selected_item.xml
+++ b/app/src/main/res/layout/spinner_selected_item.xml
@@ -8,8 +8,8 @@
     android:textSize="15sp"
     android:textStyle="bold"
     android:textColor="?attr/colorOnSurface"
-    android:paddingStart="12dp"
-    android:paddingEnd="30dp"
+    android:paddingStart="10dp"
+    android:paddingEnd="26dp"
     android:paddingTop="10dp"
     android:paddingBottom="10dp"
     android:gravity="center_vertical" />


### PR DESCRIPTION
## Description
This PR fixes the low contrast and small text size issue with the face selection dropdown in the Face Library page when running in Dark Theme.

### Key Changes
1. **Material 3 Theme-Adaptive Spinner Background**: Replaced legacy `@android:drawable/btn_dropdown` background with custom ripple background (`bg_spinner.xml`) using dynamic surface tokens (`colorSurfaceVariant` & `colorOutlineVariant`) and a tinted dropdown vector arrow (`ic_arrow_drop_down.xml`).
2. **Popup Window Styling**: Added custom shape background (`bg_spinner_popup.xml`) for the expanded dropdown popup window.
3. **Selected & Dropdown Item Layouts**:
   - Added `spinner_selected_item.xml` with text size `15sp` and `colorOnSurface` text color.
   - Added `spinner_dropdown_item.xml` with text size `15sp` and `colorOnSurface` text color.
4. **Adapter & Layout Wire-Up**:
   - Updated `savedFaceSpinner` in `item_target_face_mapping.xml` to use the new background drawables and adjusted width to `170dp`.
   - Updated `TargetFaceMappingAdapter.java` to bind the custom item layouts.

### Verification
- Ran `./gradlew assembleDebug` successfully.