### PR TITLE
ci: add Android Lint, unit tests, and lint report artifacts to CI workflow

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    name: Build Debug APK
+    name: Build & Verify Android App
     runs-on: ubuntu-latest
 
     steps:
@@ -31,8 +31,22 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Run Lint
+        run: ./gradlew lintDebug --no-daemon
+
+      - name: Run Unit Tests
+        run: ./gradlew testDebugUnitTest --no-daemon
+
       - name: Build Debug APK
         run: ./gradlew assembleDebug --no-daemon
+
+      - name: Upload Lint Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: AndroidFaceFusion-lint-report
+          path: app/build/reports/lint-results-debug.html
+          retention-days: 14
 
       - name: Upload Debug APK Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
This pull request adds Android Lint static analysis, JUnit unit tests execution, and automated lint report artifact uploading to the GitHub Actions CI pipeline.

### Changes
- Added `./gradlew lintDebug` step to catch layout, AppCompat, resource, and compatibility regressions automatically.
- Added `./gradlew testDebugUnitTest` step to run project unit test suites on every push and PR.
- Added `actions/upload-artifact@v4` step to upload the HTML lint report (`app/build/reports/lint-results-debug.html`) on both success and failure for fast diagnosis.

### Verification
- Tested complete pipeline locally (`./gradlew lintDebug testDebugUnitTest assembleDebug`). All tasks succeeded.