### PR TITLE
build: upgrade compileSdk to 37 and bump Glide to 5.0.9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.pv.androidfacefusion"
     compileSdk {
-        version = release(36)
+        version = release(37)
     }
 
     defaultConfig {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ material = "1.14.0"
 activity = "1.13.0"
 constraintlayout = "2.2.2"
 onnxruntime = "1.29.0"
-glide = "4.16.0"
+glide = "5.0.9"
 opencv = "5.0.0.1"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Upgrades `compileSdk` from 36 to 37 (`release(37)`) in `app/build.gradle.kts`
- Updates Glide dependency from 4.16.0 to 5.0.9 in `gradle/libs.versions.toml`
- Fixes `checkDebugAarMetadata` requirement for Glide 5.0.9 while preserving runtime `minSdk 26` and `targetSdk 36`

## Verification
- `./gradlew check assembleDebug assembleRelease` succeeds locally
- Android Lint analysis and Unit test suite pass
- Verified 16 KB page size alignment compliance on all 64-bit native libraries